### PR TITLE
Remove eslint as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     ]
   },
   "devDependencies": {
-    "eslint": "^8.5.0",
     "eslint-config-airbnb": "^19.0.2",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsx-a11y": "^6.5.1",


### PR DESCRIPTION
I had to remove eslint as an explicit dependency, otherwise when I try to lint the project I get the following error:

```bash
yarn lint
yarn run v1.22.17
$ eslint .

Oops! Something went wrong! :(

ESLint: 8.5.0

ESLint couldn't find the config "react-app" to extend from. Please check that the name of the config is correct.

The config "react-app" was referenced from the config file in "/home/roland/entwicklung/wger/react/package.json".

If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```


I'm also not sure if we need the other eslint packages, aren't they part of the application through the react create app?