### PR TITLE
Allow fetching more measurements than the first page only

### DIFF
--- a/src/services/measurements.test.ts
+++ b/src/services/measurements.test.ts
@@ -1,0 +1,56 @@
+import axios from "axios";
+import { MeasurementCategory } from "components/Measurements/models/Category";
+import { MeasurementEntry } from "components/Measurements/models/Entry";
+import { getMeasurementCategories } from "services/measurements";
+
+jest.mock("axios");
+
+describe('measurement service tests', () => {
+    test('GET measurement categories', async () => {
+        const measurementResponse = {
+            count: 2,
+            next: null,
+            previous: null,
+            results: [
+                {
+                    "id": 1,
+                    "name": "Weight",
+                    "unit": "kg"
+                }
+            ]
+        };
+
+        const measurementEntryResponse = {
+            count: 2,
+            next: null,
+            previous: null,
+            results: [
+                {
+                    "id": 1,
+                    "category": 1,
+                    "value": 80,
+                    "date": "2021-01-01",
+                    "notes": ""
+                }
+            ]
+        };
+
+        // @ts-ignore
+        axios.get.mockImplementation((url: string) => {
+            if (url.includes("measurement-category")) {
+                return Promise.resolve({ data: measurementResponse });
+            } else if (url.includes("measurement/?category=1")) {
+                return Promise.resolve({ data: measurementEntryResponse });
+            }
+        });
+
+        const result = await getMeasurementCategories();
+        expect(axios.get).toHaveBeenCalledTimes(2);
+
+        expect(result).toStrictEqual([
+            new MeasurementCategory(1, "Weight", "kg", [
+                new MeasurementEntry(1, 1, new Date("2021-01-01"), 80, "")
+            ])
+        ]);
+    });
+});

--- a/src/services/measurements.test.ts
+++ b/src/services/measurements.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { MeasurementCategory } from "components/Measurements/models/Category";
 import { MeasurementEntry } from "components/Measurements/models/Entry";
-import { getMeasurementCategories } from "services/measurements";
+import { getMeasurementCategories, getMeasurementCategory } from "services/measurements";
 
 jest.mock("axios");
 
@@ -52,5 +52,46 @@ describe('measurement service tests', () => {
                 new MeasurementEntry(1, 1, new Date("2021-01-01"), 80, "")
             ])
         ]);
+    });
+
+    test('GET measurement category', async () => {
+        const measurementResponse = {
+            "id": 1,
+            "name": "Weight",
+            "unit": "kg"
+        };
+
+        const measurementEntryResponse = {
+            count: 2,
+            next: null,
+            previous: null,
+            results: [
+                {
+                    "id": 1,
+                    "category": 1,
+                    "value": 80,
+                    "date": "2021-01-01",
+                    "notes": ""
+                }
+            ]
+        };
+
+        // @ts-ignore
+        axios.get.mockImplementation((url: string) => {
+            if (url.includes("measurement-category/1")) {
+                return Promise.resolve({ data: measurementResponse });
+            } else if (url.includes("measurement/?category=1")) {
+                return Promise.resolve({ data: measurementEntryResponse });
+            }
+        });
+
+        const result = await getMeasurementCategory(1);
+        expect(axios.get).toHaveBeenCalledTimes(2);
+
+        expect(result).toStrictEqual(
+            new MeasurementCategory(1, "Weight", "kg", [
+                new MeasurementEntry(1, 1, new Date("2021-01-01"), 80, "")
+            ])
+        );
     });
 });

--- a/src/services/measurements.ts
+++ b/src/services/measurements.ts
@@ -5,6 +5,7 @@ import { ApiMeasurementCategoryType, ApiMeasurementEntryType } from 'types';
 import { dateToYYYYMMDD } from "utils/date";
 import { makeHeader, makeUrl } from "utils/url";
 import { ResponseType } from "./responseType";
+import { fetchPaginated } from 'utils/requests';
 
 export const API_MEASUREMENTS_CATEGORY_PATH = 'measurement-category';
 export const API_MEASUREMENTS_ENTRY_PATH = 'measurement';
@@ -20,19 +21,23 @@ export const getMeasurementCategories = async (): Promise<MeasurementCategory[]>
     const categories = receivedCategories.results.map(l => adapter.fromJson(l));
 
     // Load entries for each category
-    const entryResponses = categories.map((category) => {
-        return axios.get<ResponseType<any>>(
-            makeUrl(API_MEASUREMENTS_ENTRY_PATH, { query: { category: category.id } }),
-            { headers: makeHeader() },
-        );
+    const entryResponses = categories.map(async (category) => {
+        const out: MeasurementEntry[] = [];
+        const url = makeUrl(API_MEASUREMENTS_ENTRY_PATH, { query: { category: category.id } });
+
+        // Collect all pages of entries
+        for await (const page of fetchPaginated(url, makeHeader())) {
+            for (const entries of page) {
+                out.push(entryAdapter.fromJson(entries));
+            }
+        }
+        return out;
     });
     const settingsResponses = await Promise.all(entryResponses);
 
     // Save entries to each category
     let categoryId: number;
-    settingsResponses.forEach((response) => {
-        const entries = response.data.results.map(l => entryAdapter.fromJson(l));
-
+    settingsResponses.forEach((entries) => {
         if (entries.length > 0) {
             categoryId = entries[0].category;
             categories.findLast(c => c.id === categoryId)!.entries = entries;


### PR DESCRIPTION
When all measurements of a specific category where fetched, it would only receive the first 20 even tough there were more. This is now fixed by fetching all pages.

See: #782