### PR TITLE
Added tooltip to add set button

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -167,6 +167,7 @@
   "noResultsDescription": "No results found for this query, consider reducing the number of filters.",
   "routines": {
     "addDay": "Add training day",
+    "addSet": "Add workout set",
     "addWeightLog": "Add training log",
     "logsHeader": "Training log for workout",
     "logsFilterNote": "Note that only entries with a weight unit of kg or lb and repetitions are charted, other combinations such as time or until failure are ignored here",

--- a/src/components/WorkoutRoutines/Detail/RoutineDetails.tsx
+++ b/src/components/WorkoutRoutines/Detail/RoutineDetails.tsx
@@ -14,6 +14,7 @@ import {
     Menu,
     MenuItem,
     Stack,
+    Tooltip,
     Typography
 } from "@mui/material";
 import { LoadingPlaceholder } from "components/Core/LoadingWidget/LoadingWidget";
@@ -251,9 +252,11 @@ const DayDetails = (props: { day: Day }) => {
                 </Stack>
             </CardContent>
             <CardActions>
-                <IconButton onClick={navigateAddSet}>
-                    <Add />
-                </IconButton>
+                <Tooltip title={t('routines.addSet')} placement="bottom">
+                    <IconButton onClick={navigateAddSet}>
+                        <Add />
+                    </IconButton>
+                </Tooltip>
             </CardActions>
         </Card>
     );


### PR DESCRIPTION
This is in relation to issue #915.

Added a Tooltip around the card action button that routes to adding a new workout set to a workout day. I've set it to behave the same as Tooltips in the nutrition log. A future change could be to adjust the text size, since it's quite small.