### PR TITLE
Better handling of dynamic translations

### DIFF
--- a/src/components/BodyWeight/Form/WeightForm.test.tsx
+++ b/src/components/BodyWeight/Form/WeightForm.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from "@testing-library/user-event";
 import { WeightForm } from "components/BodyWeight/Form/WeightForm";
 import { WeightEntry } from "components/BodyWeight/model";
 import { useAddWeightEntryQuery, useBodyWeightQuery, useEditWeightEntryQuery } from "components/BodyWeight/queries";
@@ -37,7 +38,7 @@ describe("Test WeightForm component", () => {
         // Assert
         expect(screen.getByDisplayValue('2021-12-10')).toBeInTheDocument();
         expect(screen.getByDisplayValue('80')).toBeInTheDocument();
-        expect(screen.getByLabelText('date')).toBeInTheDocument();
+        expect(screen.getAllByLabelText('date').length).toBeGreaterThan(0);
         expect(screen.getByLabelText('weight')).toBeInTheDocument();
         expect(screen.getByText('submit')).toBeInTheDocument();
     });
@@ -70,24 +71,27 @@ describe("Test WeightForm component", () => {
     test('Creating a new weight entry', async () => {
 
         // Arrange
+        const user = userEvent.setup();
         render(
             <QueryClientProvider client={testQueryClient}>
                 <WeightForm />
             </QueryClientProvider>
         );
-        const dateInput = await screen.findByLabelText('date');
+
+        const group = screen.getByRole('group', { name: /date/i });
+        const dateInput = within(group).getByRole('textbox', { hidden: true });
         const weightInput = await screen.findByLabelText('weight');
         const submitButton = screen.getByRole('button', { name: 'submit' });
 
         // Act
-        fireEvent.input(dateInput, { target: { value: '2022-02-28' } });
-        fireEvent.input(weightInput, { target: { value: '80' } });
+        user.type(dateInput, '2022-02-28');
+        user.type(weightInput, '80');
 
         // Assert
         expect(dateInput).toBeInTheDocument();
         expect(weightInput).toBeInTheDocument();
         expect(submitButton).toBeInTheDocument();
-        fireEvent.click(submitButton);
+        user.click(submitButton);
         await waitFor(() => {
             expect(useAddWeightEntryQuery).toHaveBeenCalled();
         });

--- a/src/components/BodyWeight/Form/WeightForm.test.tsx
+++ b/src/components/BodyWeight/Form/WeightForm.test.tsx
@@ -91,7 +91,7 @@ describe("Test WeightForm component", () => {
         expect(dateInput).toBeInTheDocument();
         expect(weightInput).toBeInTheDocument();
         expect(submitButton).toBeInTheDocument();
-        user.click(submitButton);
+        await user.click(submitButton);
         await waitFor(() => {
             expect(useAddWeightEntryQuery).toHaveBeenCalled();
         });

--- a/src/components/Exercises/Add/Step1Basics.test.tsx
+++ b/src/components/Exercises/Add/Step1Basics.test.tsx
@@ -30,9 +30,6 @@ jest.mock("state/exerciseSubmissionReducer", () => {
         setEquipment: jest.fn(),
         setPrimaryMuscles: jest.fn(),
         setSecondaryMuscles: jest.fn()
-
-        // TODO: mocking primary and secondary muscles break the test
-        // setPrimaryMuscles: jest.fn()
     };
 });
 
@@ -105,10 +102,10 @@ describe("<Step1Basics />", () => {
         await user.keyboard('{enter}');
 
         await user.click(screen.getByLabelText('category'));
-        await user.click(screen.getByText('server.arms'));
+        await user.click(screen.getByText('Arms'));
 
         await user.click(screen.getByLabelText('exercises.equipment'));
-        await user.click(screen.getByText('server.rocks'));
+        await user.click(screen.getByText('Rocks'));
 
         const muscles = screen.getByLabelText('exercises.muscles');
         await user.click(muscles);

--- a/src/components/Exercises/Add/Step1Basics.tsx
+++ b/src/components/Exercises/Add/Step1Basics.tsx
@@ -14,7 +14,6 @@ import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useExerciseSubmissionStateValue } from "state";
 import * as exerciseReducer from "state/exerciseSubmissionReducer";
-import { getTranslationKey } from "utils/strings";
 import * as yup from "yup";
 
 export const Step1Basics = ({ onContinue }: StepProps) => {
@@ -76,7 +75,7 @@ export const Step1Basics = ({ onContinue }: StepProps) => {
                                     fieldName={'category'}
                                     options={categoryQuery.data!.map(category => (
                                         <MenuItem key={category.id} value={category.id}>
-                                            {t(getTranslationKey(category.name))}
+                                            {category.translatedName}
                                         </MenuItem>
                                     ))}
                                 />
@@ -97,7 +96,7 @@ export const Step1Basics = ({ onContinue }: StepProps) => {
                                         getOptionDisabled={(option) =>
                                             secondaryMuscles.includes(option)
                                         }
-                                        getOptionLabel={option => musclesQuery.data!.find(m => m.id === option)!.getName(t)}
+                                        getOptionLabel={option => musclesQuery.data!.find(m => m.id === option)!.getName()}
                                         value={primaryMuscles}
                                         onChange={(event, newValue) => {
                                             setPrimaryMuscles(newValue);
@@ -124,7 +123,7 @@ export const Step1Basics = ({ onContinue }: StepProps) => {
                                         getOptionDisabled={(option) =>
                                             primaryMuscles.includes(option)
                                         }
-                                        getOptionLabel={option => musclesQuery.data!.find(m => m.id === option)!.getName(t)}
+                                        getOptionLabel={option => musclesQuery.data!.find(m => m.id === option)!.getName()}
                                         value={secondaryMuscles}
                                         onChange={(event, newValue) => {
                                             setSecondaryMuscles(newValue);

--- a/src/components/Exercises/Add/Step6Overview.test.tsx
+++ b/src/components/Exercises/Add/Step6Overview.test.tsx
@@ -88,8 +88,8 @@ describe("Test the add exercise step 6 component", () => {
         expect(screen.getByText('A new exercise')).toBeInTheDocument();
         expect(screen.getByText('This very nice exercise will blow your mind')).toBeInTheDocument();
 
-        expect(screen.getByText('server.arms')).toBeInTheDocument();
-        expect(screen.getByText('server.dumbbell')).toBeInTheDocument();
+        expect(screen.getByText('Arms')).toBeInTheDocument();
+        expect(screen.getByText('Dumbbell')).toBeInTheDocument();
         expect(screen.getByText('exercises.step1HeaderBasics')).toBeInTheDocument();
         expect(screen.getByText(/Musculus dacttilaris/i)).toBeInTheDocument();
 

--- a/src/components/Exercises/Add/Step6Overview.tsx
+++ b/src/components/Exercises/Add/Step6Overview.tsx
@@ -27,7 +27,6 @@ import { addNote } from "services/note";
 import { addVariation } from "services/variation";
 import { useExerciseSubmissionStateValue } from "state";
 import { ENGLISH_LANGUAGE_ID } from "utils/consts";
-import { getTranslationKey } from "utils/strings";
 import { makeLink, WgerLink } from "utils/url";
 
 export const Step6Overview = ({ onBack }: StepProps) => {
@@ -151,19 +150,19 @@ export const Step6Overview = ({ onBack }: StepProps) => {
                         </TableRow>
                         <TableRow>
                             <TableCell>{t('category')}</TableCell>
-                            <TableCell>{t(getTranslationKey(categoryQuery.data!.find(c => c.id === state.category)!.name))}</TableCell>
+                            <TableCell>{categoryQuery.data!.find(c => c.id === state.category)!.translatedName}</TableCell>
                         </TableRow>
                         <TableRow>
                             <TableCell>{t('exercises.equipment')}</TableCell>
-                            <TableCell>{state.equipment.map(e => t(getTranslationKey(equipmentQuery.data!.find(value => value.id === e)!.name))).join(', ')}</TableCell>
+                            <TableCell>{state.equipment.map(e => equipmentQuery.data!.find(value => value.id === e)!.translatedName).join(', ')}</TableCell>
                         </TableRow>
                         <TableRow>
                             <TableCell>{t('exercises.muscles')}</TableCell>
-                            <TableCell>{state.muscles.map(m => musclesQuery.data!.find(value => value.id === m)!.getName(t)).join(', ')}</TableCell>
+                            <TableCell>{state.muscles.map(m => musclesQuery.data!.find(value => value.id === m)!.getName()).join(', ')}</TableCell>
                         </TableRow>
                         <TableRow>
                             <TableCell>{t('exercises.secondaryMuscles')}</TableCell>
-                            <TableCell>{state.musclesSecondary.map(m => musclesQuery.data!.find(value => value.id === m)!.getName(t)).join(', ')}</TableCell>
+                            <TableCell>{state.musclesSecondary.map(m => musclesQuery.data!.find(value => value.id === m)!.getName()).join(', ')}</TableCell>
                         </TableRow>
                         <TableRow>
                             <TableCell>{t('exercises.variations')}</TableCell>

--- a/src/components/Exercises/Detail/ExerciseDetailView.tsx
+++ b/src/components/Exercises/Detail/ExerciseDetailView.tsx
@@ -127,7 +127,7 @@ export const ExerciseDetailView = ({
                         <h3>{t("exercises.primaryMuscles")}</h3>
                         <ul>
                             {exercise.muscles.map((m: Muscle) => (
-                                <li key={m.id}>{m.getName(t)}</li>
+                                <li key={m.id}>{m.getName()}</li>
                             ))}
                         </ul>
                     </Grid>
@@ -155,7 +155,7 @@ export const ExerciseDetailView = ({
                         <h3>{t("exercises.secondaryMuscles")}</h3>
                         <ul>
                             {exercise.musclesSecondary.map((m: Muscle) => (
-                                <li key={m.id}>{m.getName(t)}</li>
+                                <li key={m.id}>{m.getName()}</li>
                             ))}
                         </ul>
                     </Grid>

--- a/src/components/Exercises/Detail/ExerciseDetails.test.tsx
+++ b/src/components/Exercises/Detail/ExerciseDetails.test.tsx
@@ -76,8 +76,8 @@ describe("Render tests", () => {
         expect(screen.getByText("exercises.description")).toBeInTheDocument();
         expect(screen.getByText("Squats")).toBeInTheDocument();
 
-        expect(screen.getByText("Biggus musculus (server.big_muscle)")).toBeInTheDocument();
-        expect(screen.getByText('Rectus abdominis (server.abs)')).toBeInTheDocument();
+        expect(screen.getByText("Biggus musculus (Big muscle)")).toBeInTheDocument();
+        expect(screen.getByText('Rectus abdominis (Abs)')).toBeInTheDocument();
 
         // Header is only shown for exercises that have variations
 

--- a/src/components/Exercises/Detail/Head/ExerciseDeleteDialog.test.tsx
+++ b/src/components/Exercises/Detail/Head/ExerciseDeleteDialog.test.tsx
@@ -90,7 +90,6 @@ describe("Test the ExerciseDeleteDialog component", () => {
             await new Promise((r) => setTimeout(r, 250));
         });
         await user.click(screen.getByTestId('autocompleter-result-998'));
-        //screen.logTestingPlaygroundURL();
         expect(getExercise).toHaveBeenCalledWith(998);
         expect(screen.queryByText("exercises.noReplacementSelected")).not.toBeInTheDocument();
         expect(screen.getByText("Benchpress")).toBeInTheDocument();
@@ -99,8 +98,6 @@ describe("Test the ExerciseDeleteDialog component", () => {
         await user.click(screen.getByTestId('button-delete-and-replace'));
         expect(deleteExercise).toHaveBeenCalledWith(345, "abcdef-150a-4ac7-97ef-84643c6419bf");
         expect(deleteExerciseTranslation).not.toHaveBeenCalled();
-
-        //screen.logTestingPlaygroundURL();
     });
 
     test('correctly sets a replacement manually setting the ID', async () => {

--- a/src/components/Exercises/Detail/Head/index.tsx
+++ b/src/components/Exercises/Detail/Head/index.tsx
@@ -23,7 +23,6 @@ import { WgerPermissions } from "permissions";
 import React, { useState } from 'react';
 import { useTranslation } from "react-i18next";
 import { Link } from 'react-router-dom';
-import { getTranslationKey } from "utils/strings";
 import styles from './head.module.css';
 
 export interface HeadProp {
@@ -157,10 +156,16 @@ export const Head = ({
                         }
                     </div>
                     <Stack direction="row" spacing={1} mt={2}>
-                        <Chip label={t(getTranslationKey(exercise.category.name))} size="small" />
+                        <Chip
+                            label={exercise.category.translatedName}
+                            size="small" />
                         {exercise.equipment.map(e => {
-                            return <Chip key={e.id} label={t(getTranslationKey(e.name))} variant="outlined"
-                                         size="small" />;
+                            return <Chip
+                                key={e.id}
+                                label={e.translatedName}
+                                variant="outlined"
+                                size="small"
+                            />;
                         })}
                     </Stack>
                 </div>

--- a/src/components/Exercises/Detail/OverviewCard.test.tsx
+++ b/src/components/Exercises/Detail/OverviewCard.test.tsx
@@ -50,9 +50,9 @@ describe("Test the exercise overview card component", () => {
 
         // Assert
         expect(screen.getByText("Squats")).toBeInTheDocument();
-        expect(screen.getByText("server.abs")).toBeInTheDocument();
-        expect(screen.getByText("server.kettlebell")).toBeInTheDocument();
-        expect(screen.getByText("server.test_123")).toBeInTheDocument();
+        expect(screen.getByText("Abs")).toBeInTheDocument();
+        expect(screen.getByText("Kettlebell")).toBeInTheDocument();
+        expect(screen.getByText("Test 123")).toBeInTheDocument();
     });
 
     test("Render the overview card with an existing translation", async () => {
@@ -71,9 +71,9 @@ describe("Test the exercise overview card component", () => {
         expect(screen.queryByText("Squats")).not.toBeInTheDocument();
         expect(screen.getByText("Kniebeuge")).toBeInTheDocument();
 
-        expect(screen.getByText("server.abs")).toBeInTheDocument();
-        expect(screen.getByText("server.kettlebell")).toBeInTheDocument();
-        expect(screen.getByText("server.test_123")).toBeInTheDocument();
+        expect(screen.getByText("Abs")).toBeInTheDocument();
+        expect(screen.getByText("Kettlebell")).toBeInTheDocument();
+        expect(screen.getByText("Test 123")).toBeInTheDocument();
     });
 
     test("Render the overview card with a non existing translation -> fallback to english", async () => {
@@ -91,8 +91,8 @@ describe("Test the exercise overview card component", () => {
         // Assert
         expect(screen.queryByText("Kniebeuge")).not.toBeInTheDocument();
         expect(screen.getByText("Squats")).toBeInTheDocument();
-        expect(screen.getByText("server.abs")).toBeInTheDocument();
-        expect(screen.getByText("server.kettlebell")).toBeInTheDocument();
-        expect(screen.getByText("server.test_123")).toBeInTheDocument();
+        expect(screen.getByText("Abs")).toBeInTheDocument();
+        expect(screen.getByText("Kettlebell")).toBeInTheDocument();
+        expect(screen.getByText("Test 123")).toBeInTheDocument();
     });
 });

--- a/src/components/Exercises/Detail/OverviewCard.tsx
+++ b/src/components/Exercises/Detail/OverviewCard.tsx
@@ -6,7 +6,6 @@ import { Language } from "components/Exercises/models/language";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { ENGLISH_LANGUAGE_ID } from "utils/consts";
-import { getTranslationKey } from "utils/strings";
 import { makeLink, WgerLink } from "utils/url";
 
 type OverviewCardProps = {
@@ -46,7 +45,7 @@ export const OverviewCard = ({ exercise, language }: OverviewCardProps) => {
                     </Tooltip>
 
                     <Chip
-                        label={t(getTranslationKey(exercise.category.name))}
+                        label={exercise.category.translatedName}
                         key={exercise.category.id}
                         sx={{ position: "absolute", top: 8, left: 8 }}
                         color="primary"
@@ -54,7 +53,7 @@ export const OverviewCard = ({ exercise, language }: OverviewCardProps) => {
                     />
                     {exercise.equipment.map(equipment => (
                         <Typography display="inline" mr={1} key={equipment.id}>
-                            {t(getTranslationKey(equipment.name))}
+                            {equipment.translatedName}
                         </Typography>
                     ))}
                     {exercise.equipment.length === 0 && (

--- a/src/components/Exercises/ExerciseOverview.test.tsx
+++ b/src/components/Exercises/ExerciseOverview.test.tsx
@@ -77,7 +77,7 @@ describe("Test the ExerciseOverview component", () => {
         );
         await act(() => Promise.resolve());
         const { getByText: categoriesComponent } = within(screen.getByTestId('categories'));
-        fireEvent.click(categoriesComponent("server.arms"));
+        fireEvent.click(categoriesComponent("Arms"));
 
         // Assert
         expect(screen.queryByText('Benchpress')).not.toBeInTheDocument();
@@ -99,8 +99,8 @@ describe("Test the ExerciseOverview component", () => {
         );
         await act(() => Promise.resolve());
         const { getByText: categoriesComponent } = within(screen.getByTestId('categories'));
-        fireEvent.click(categoriesComponent("server.arms"));
-        fireEvent.click(categoriesComponent("server.legs"));
+        fireEvent.click(categoriesComponent("Arms"));
+        fireEvent.click(categoriesComponent("Legs"));
 
         // Assert
         expect(screen.getByText('Squats')).toBeInTheDocument();
@@ -122,7 +122,7 @@ describe("Test the ExerciseOverview component", () => {
         );
         await act(() => Promise.resolve());
         const { getByText: equipmentComponent } = within(screen.getByTestId('equipment'));
-        fireEvent.click(equipmentComponent("server.barbell"));
+        fireEvent.click(equipmentComponent("Barbell"));
 
         // Assert
         expect(screen.getByText('Squats')).toBeInTheDocument();
@@ -167,10 +167,10 @@ describe("Test the ExerciseOverview component", () => {
         await act(() => Promise.resolve());
 
         const { getByText: categoryComponent } = within(screen.getByTestId('categories'));
-        fireEvent.click(categoryComponent('server.legs'));
+        fireEvent.click(categoryComponent('Legs'));
 
         const { getByText: equipmentComponent } = within(screen.getByTestId('equipment'));
-        fireEvent.click(equipmentComponent('server.rocks'));
+        fireEvent.click(equipmentComponent('Rocks'));
 
         // Assert
         expect(screen.getByText('Squats')).toBeInTheDocument();

--- a/src/components/Exercises/Filter/CategoryFilter.test.tsx
+++ b/src/components/Exercises/Filter/CategoryFilter.test.tsx
@@ -44,13 +44,13 @@ describe("Test the CategoryFilter component", () => {
         );
 
         // Assert
-        const cat1Element = await screen.findByText("server.abs");
+        const cat1Element = await screen.findByText("Abs");
         expect(cat1Element).toBeInTheDocument();
 
-        const cat2Element = await screen.findByText("server.arms");
+        const cat2Element = await screen.findByText("Arms");
         expect(cat2Element).toBeInTheDocument();
 
-        const cat3Element = await screen.findByText("server.back");
+        const cat3Element = await screen.findByText("Back");
         expect(cat3Element).toBeInTheDocument();
     });
 

--- a/src/components/Exercises/Filter/CategoryFilter.tsx
+++ b/src/components/Exercises/Filter/CategoryFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
     Accordion,
     AccordionDetails,
@@ -12,13 +12,12 @@ import {
     Switch,
     Typography
 } from "@mui/material";
-import { useTranslation } from "react-i18next";
 import { Category } from "components/Exercises/models/category";
-import { getTranslationKey } from "utils/strings";
+import React, { useContext } from 'react';
+import { useTranslation } from "react-i18next";
+import { LoadingPlaceholder } from '../../Core/LoadingWidget/LoadingWidget';
 import { useCategoriesQuery } from '../queries';
 import { ExerciseFiltersContext } from './ExerciseFiltersContext';
-import { LoadingPlaceholder } from '../../Core/LoadingWidget/LoadingWidget';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 const CategoryFilterList = () => {
 
@@ -64,7 +63,10 @@ const CategoryFilterList = () => {
                                     inputProps={{ 'aria-labelledby': labelId }}
                                 />
                             </ListItemIcon>
-                            <ListItemText id={labelId} primary={t(getTranslationKey(category.name))} />
+                            <ListItemText
+                                id={labelId}
+                                primary={category.translatedName}
+                            />
                         </ListItemButton>
                     </ListItem>
                 );

--- a/src/components/Exercises/Filter/EquipmentFilter.test.tsx
+++ b/src/components/Exercises/Filter/EquipmentFilter.test.tsx
@@ -42,13 +42,13 @@ describe("Test the CategoryFilter component", () => {
             </ExerciseFiltersContext.Provider>);
 
         // Assert
-        const cat1Element = await screen.findByText("server.bench");
+        const cat1Element = await screen.findByText("Bench");
         expect(cat1Element).toBeInTheDocument();
 
-        const cat2Element = await screen.findByText("server.kettlebell");
+        const cat2Element = await screen.findByText("Kettlebell");
         expect(cat2Element).toBeInTheDocument();
 
-        const cat3Element = await screen.findByText("server.dumbbell");
+        const cat3Element = await screen.findByText("Dumbbell");
         expect(cat3Element).toBeInTheDocument();
     });
 

--- a/src/components/Exercises/Filter/EquipmentFilter.tsx
+++ b/src/components/Exercises/Filter/EquipmentFilter.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {
     Accordion,
     AccordionDetails,
@@ -12,13 +12,12 @@ import {
     Switch,
     Typography
 } from "@mui/material";
-import { useTranslation } from "react-i18next";
 import { Equipment } from "components/Exercises/models/equipment";
-import { getTranslationKey } from "utils/strings";
+import React, { useContext } from 'react';
+import { useTranslation } from "react-i18next";
+import { LoadingPlaceholder } from '../../Core/LoadingWidget/LoadingWidget';
 import { useEquipmentQuery } from '../queries';
 import { ExerciseFiltersContext } from './ExerciseFiltersContext';
-import { LoadingPlaceholder } from '../../Core/LoadingWidget/LoadingWidget';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 const EquipmentFilterList = () => {
 
@@ -40,7 +39,7 @@ const EquipmentFilterList = () => {
     };
 
     if (isLoading) {
-        return <LoadingPlaceholder/>;
+        return <LoadingPlaceholder />;
     }
 
     return (
@@ -64,7 +63,10 @@ const EquipmentFilterList = () => {
                                     inputProps={{ 'aria-labelledby': labelId }}
                                 />
                             </ListItemIcon>
-                            <ListItemText id={labelId} primary={t(getTranslationKey(equipment.name))}/>
+                            <ListItemText
+                                id={labelId}
+                                primary={equipment.translatedName}
+                            />
                         </ListItemButton>
                     </ListItem>
                 );
@@ -78,11 +80,11 @@ export const EquipmentFilterDropdown = () => {
 
     return (
         <Accordion>
-            <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 {t('exercises.equipment')}
             </AccordionSummary>
             <AccordionDetails>
-                <EquipmentFilterList/>
+                <EquipmentFilterList />
             </AccordionDetails>
         </Accordion>
     );
@@ -97,7 +99,7 @@ export const EquipmentFilter = () => {
                 <Typography gutterBottom variant="h6" m={2}>
                     {t('exercises.equipment')}
                 </Typography>
-                <EquipmentFilterList/>
+                <EquipmentFilterList />
             </Paper>
         </div>
     );

--- a/src/components/Exercises/Filter/MuscleFilter.tsx
+++ b/src/components/Exercises/Filter/MuscleFilter.tsx
@@ -20,7 +20,6 @@ import { Muscle } from "components/Exercises/models/muscle";
 import { MuscleOverview } from "components/Muscles/MuscleOverview";
 import React, { useContext } from 'react';
 import { useTranslation } from "react-i18next";
-import { getTranslationKey } from "utils/strings";
 import { useMusclesQuery } from '../queries';
 import { ExerciseFiltersContext } from './ExerciseFiltersContext';
 
@@ -88,7 +87,8 @@ const MuscleFilterList = () => {
                             <ListItemText
                                 id={labelId}
                                 primary={m.name}
-                                secondary={m.nameEn !== '' ? t(getTranslationKey(m.nameEn)) : ''} />
+                                secondary={m.nameEn !== '' ? m.translatedName : ''}
+                            />
 
                         </ListItemButton>
                     </ListItem>

--- a/src/components/Exercises/forms/Category.tsx
+++ b/src/components/Exercises/forms/Category.tsx
@@ -4,7 +4,6 @@ import { useProfileQuery } from "components/User/queries/profile";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { editExercise } from "services";
-import { getTranslationKey } from "utils/strings";
 
 export function EditExerciseCategory(props: { exerciseId: number, initial: number }) {
     const { t } = useTranslation();
@@ -33,7 +32,7 @@ export function EditExerciseCategory(props: { exerciseId: number, initial: numbe
         >
             {categoryQuery.data!.map(category => (
                 <MenuItem key={category.id} value={category.id}>
-                    {t(getTranslationKey(category.name))}
+                    {category.translatedName}
                 </MenuItem>
             ))}
         </Select>

--- a/src/components/Exercises/forms/Equipment.tsx
+++ b/src/components/Exercises/forms/Equipment.tsx
@@ -4,7 +4,6 @@ import { useProfileQuery } from "components/User/queries/profile";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { editExercise } from "services";
-import { getTranslationKey } from "utils/strings";
 
 export function EditExerciseEquipment(props: { exerciseId: number, initial: number[] }) {
     const { t } = useTranslation();
@@ -24,7 +23,7 @@ export function EditExerciseEquipment(props: { exerciseId: number, initial: numb
             multiple
             value={value}
             options={equipmentQuery.data.map(e => e.id)}
-            getOptionLabel={option => t(getTranslationKey(equipmentQuery.data.find(e => e.id === option)!.name))}
+            getOptionLabel={option => equipmentQuery.data.find(e => e.id === option)!.translatedName}
             onChange={(event, newValue) => handleOnChange(newValue)}
             renderInput={params => (
                 <TextField

--- a/src/components/Exercises/forms/ExerciseEquipmentSelect.tsx
+++ b/src/components/Exercises/forms/ExerciseEquipmentSelect.tsx
@@ -1,8 +1,7 @@
-import { useTranslation } from "react-i18next";
 import { Autocomplete, TextField } from "@mui/material";
-import React from "react";
 import { useField } from "formik";
-import { getTranslationKey } from "utils/strings";
+import React from "react";
+import { useTranslation } from "react-i18next";
 
 export function ExerciseEquipmentSelect(props: { fieldName: string, options: any[] }) {
     const [t] = useTranslation();
@@ -12,7 +11,7 @@ export function ExerciseEquipmentSelect(props: { fieldName: string, options: any
         multiple
         id={props.fieldName}
         options={props.options.map(e => e.id)}
-        getOptionLabel={option => t(getTranslationKey(props.options.find(e => e.id === option)!.name))}
+        getOptionLabel={option => props.options.find(e => e.id === option)!.translatedName}
         {...field}
         onChange={(event, newValue) => {
             helpers.setValue(newValue);

--- a/src/components/Exercises/models/category.ts
+++ b/src/components/Exercises/models/category.ts
@@ -1,4 +1,7 @@
+import i18n from "i18n";
 import { Adapter } from "utils/Adapter";
+import { getTranslationKey } from "utils/strings";
+
 
 export class Category {
 
@@ -6,6 +9,10 @@ export class Category {
         public id: number,
         public name: string
     ) {
+    }
+
+    public get translatedName(): string {
+        return i18n.t(getTranslationKey(this.name), { defaultValue: this.name });
     }
 }
 

--- a/src/components/Exercises/models/equipment.ts
+++ b/src/components/Exercises/models/equipment.ts
@@ -1,4 +1,6 @@
+import i18n from "i18n";
 import { Adapter } from "utils/Adapter";
+import { getTranslationKey } from "utils/strings";
 
 export class Equipment {
 
@@ -6,6 +8,10 @@ export class Equipment {
         public id: number,
         public name: string
     ) {
+    }
+
+    public get translatedName(): string {
+        return i18n.t(getTranslationKey(this.name), { defaultValue: this.name });
     }
 }
 

--- a/src/components/Exercises/models/muscle.test.ts
+++ b/src/components/Exercises/models/muscle.test.ts
@@ -4,15 +4,14 @@ import { Muscle } from "components/Exercises/models/muscle";
 describe("Muscle model tests", () => {
 
     test('name helper', () => {
- 
+
         // Arrange
-        const t = (a: string) => 'translated name';
         const m1 = new Muscle(2, "Anterior deltoid", "Shoulders", true);
         const m2 = new Muscle(2, "Anterior deltoid", "", true);
 
         // Assert
-        expect(m1.getName(t)).toBe("Anterior deltoid (translated name)");
-        expect(m2.getName(t)).toBe("Anterior deltoid");
+        expect(m1.getName()).toBe("Anterior deltoid (Shoulders)");
+        expect(m2.getName()).toBe("Anterior deltoid");
     });
 });
 

--- a/src/components/Exercises/models/muscle.ts
+++ b/src/components/Exercises/models/muscle.ts
@@ -1,3 +1,4 @@
+import i18n from 'i18next';
 import { Adapter } from "utils/Adapter";
 import { getTranslationKey } from "utils/strings";
 
@@ -10,10 +11,14 @@ export class Muscle {
     ) {
     }
 
+    public get translatedName(): string {
+        return i18n.t(getTranslationKey(this.nameEn), { defaultValue: this.nameEn });
+    }
+
     // Return the name and english name of the muscle, if available.
-    public getName(t: Function): string {
+    public getName(): string {
         if (this.nameEn) {
-            return `${this.name} (${t(getTranslationKey(this.nameEn))})`;
+            return `${this.name} (${this.translatedName})`;
         } else {
             return this.name;
         }

--- a/src/components/Measurements/widgets/EntryForm.test.tsx
+++ b/src/components/Measurements/widgets/EntryForm.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from "@testing-library/user-event";
 import {
     useAddMeasurementEntryQuery,
@@ -51,7 +51,7 @@ describe("Test the EntryForm component", () => {
         expect(screen.getByDisplayValue('2023-02-01')).toBeInTheDocument();
         expect(screen.getByDisplayValue('10')).toBeInTheDocument();
         expect(screen.getByDisplayValue('test note')).toBeInTheDocument();
-        expect(screen.getByLabelText('date')).toBeInTheDocument();
+        expect(screen.getAllByLabelText('date').length).toBeGreaterThan(0);
         expect(screen.getByLabelText('value')).toBeInTheDocument();
         expect(screen.getByLabelText('notes')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: 'submit' })).toBeInTheDocument();
@@ -94,13 +94,13 @@ describe("Test the EntryForm component", () => {
                 <EntryForm categoryId={11} />
             </QueryClientProvider>
         );
-        const dateInput = await screen.findByLabelText('date');
+        const group = screen.getByRole('group', { name: /date/i });
+        const dateInput = within(group).getByRole('textbox', { hidden: true });
         const valueInput = await screen.findByLabelText('value');
         const notesInput = await screen.findByLabelText('notes');
         const submitButton = screen.getByRole('button', { name: 'submit' });
 
         // Act
-        await user.clear(dateInput);
         await user.type(dateInput, '2023-06-18');
         await user.clear(valueInput);
         await user.type(valueInput, '42.42');

--- a/src/components/WorkoutRoutines/widgets/RoutineStatistics.test.tsx
+++ b/src/components/WorkoutRoutines/widgets/RoutineStatistics.test.tsx
@@ -61,7 +61,7 @@ describe('Tests for the getHumanReadableHeaders helper', () => {
             StatGroupBy.Muscles,
             mockLogData
         );
-        expect(result.headers).toEqual(["server.finger_muscle", "server.shoulders"]);
+        expect(result.headers).toEqual(["Finger muscle", "Shoulders"]);
         expect(result.data).toEqual([10, 15]);
     });
 
@@ -153,13 +153,13 @@ describe('Tests for the getFullStatsData function', () => {
             'en',
         );
 
-        expect(result.headers).toEqual(['server.finger_muscle', 'server.shoulders']);
+        expect(result.headers).toEqual(['Finger muscle', 'Shoulders']);
         expect(result.data).toEqual([
             { key: 'week 1', values: [5, 10] },
             { key: 'week 2', values: [8, 12] }
         ]);
 
-        expect(result.totals).toEqual({ 'server.finger_muscle': 13, 'server.shoulders': 22 });
+        expect(result.totals).toEqual({ 'Finger muscle': 13, 'Shoulders': 22 });
     });
 
 
@@ -217,12 +217,12 @@ describe('Tests for the getFullStatsData function', () => {
             mockLanguage,
             'en',
         );
-        expect(result.headers).toEqual(['server.finger_muscle', 'server.shoulders']);
+        expect(result.headers).toEqual(['Finger muscle', 'Shoulders']);
         expect(result.data).toEqual([
             { key: "3/1/2024", values: [15, 10] },
             { key: "3/3/2024", values: [18, 12] }
         ]);
-        expect(result.totals).toEqual({ "server.finger_muscle": 33, "server.shoulders": 22 });
+        expect(result.totals).toEqual({ "Finger muscle": 33, "Shoulders": 22 });
     });
 });
 
@@ -295,14 +295,14 @@ describe('formatStatsData', () => {
     it('should format data correctly for weekly', () => {
 
         const mockFullStatsData = {
-            headers: ['server.finger_muscle', 'server.shoulders'],
+            headers: ['Finger Muscle', 'Shoulders'],
             data: [
                 { key: 'week 1', values: [5, 10] },
                 { key: 'week 2', values: [8, 12] }
             ],
             totals: {
-                'server.finger_muscle': 13,
-                'server.shoulders': 22
+                'Finger Muscle': 13,
+                'Shoulders': 22
             }
         };
 
@@ -313,14 +313,14 @@ describe('formatStatsData', () => {
                 { category: "week 1", value: 5 },
                 { category: "week 2", value: 8 }
             ],
-            "name": "server.finger_muscle"
+            "name": "Finger Muscle"
         },
             {
                 "data": [
                     { category: "week 1", value: 10 },
                     { category: "week 2", value: 12 }
                 ],
-                "name": "server.shoulders"
+                "name": "Shoulders"
             }
         ]);
 

--- a/src/components/WorkoutRoutines/widgets/RoutineStatistics.tsx
+++ b/src/components/WorkoutRoutines/widgets/RoutineStatistics.tsx
@@ -7,7 +7,6 @@ import { Muscle } from "components/Exercises/models/muscle";
 import { GroupedLogData, LogData, RoutineStatsData } from "components/WorkoutRoutines/models/LogStats";
 import i18n from 'i18next';
 import React from "react";
-import { getTranslationKey } from "utils/strings";
 
 export const enum StatType {
     Volume = "volume",
@@ -77,8 +76,7 @@ export function getHumanReadableHeaders(exerciseList: Exercise[], language: Lang
             return { headers: exercises as string[], data: exercisesIds.map(ex => logData.exercises[ex]) };
         }
         case StatGroupBy.Muscles: {
-            // @ts-expect-error We know the translation key exists
-            const muscles = Object.keys(logData.muscle).map(e => i18n.t(getTranslationKey(muscleList.find(m => m.id === parseInt(e))?.nameEn)));
+            const muscles = Object.keys(logData.muscle).map(e => muscleList.find(m => m.id === parseInt(e))?.translatedName ?? '');
             const musclesIds = Object.keys(logData.muscle).map(Number);
             return { headers: muscles as string[], data: musclesIds.map(ms => logData.muscle[ms]) };
 

--- a/src/components/WorkoutRoutines/widgets/forms/RoutineForm.test.tsx
+++ b/src/components/WorkoutRoutines/widgets/forms/RoutineForm.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { RoutineForm } from "components/WorkoutRoutines/widgets/forms/RoutineForm";
 import { BrowserRouter } from "react-router-dom";
@@ -34,8 +34,11 @@ describe('RoutineForm', () => {
 
         // Assert
         expect(screen.getByRole('textbox', { name: /name/i })).toHaveValue('Test routine 1');
-        expect(screen.getByRole('textbox', { name: /start/i })).toHaveValue('05/01/2024');
-        expect(screen.getByRole('textbox', { name: /end/i })).toHaveValue('06/01/2024');
+        const groupStart = screen.getByRole('group', { name: /start/i });
+        expect(within(groupStart).getByRole('textbox', { hidden: true })).toHaveValue('05/01/2024');
+
+        const groupEnd = screen.getByRole('group', { name: /end/i });
+        expect(within(groupEnd).getByRole('textbox', { hidden: true })).toHaveValue('06/01/2024');
         expect(screen.getByRole('textbox', { name: /description/i })).toHaveValue('Full body routine');
     });
 

--- a/src/components/WorkoutRoutines/widgets/forms/SessionForm.test.tsx
+++ b/src/components/WorkoutRoutines/widgets/forms/SessionForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { WorkoutSession } from "components/WorkoutRoutines/models/WorkoutSession";
 import { useAddSessionQuery, useEditSessionQuery, useFindSessionQuery } from "components/WorkoutRoutines/queries";
@@ -60,7 +60,7 @@ describe('SessionForm', () => {
         );
 
         // Assert
-        const datePicker = screen.getByRole('textbox', { name: /date/i });
+        const datePicker = screen.getByRole('group', { name: /date/i });
         const newDate = DateTime.now();
 
         await user.type(datePicker, newDate.toFormat('yyyy-MM-dd'));
@@ -121,16 +121,22 @@ describe('SessionForm', () => {
             </BrowserRouter>
         );
 
+        screen.logTestingPlaygroundURL();
+
         // Assert
         await waitFor(() => {
             // screen.logTestingPlaygroundURL();
             expect((screen.getByRole('textbox', { name: /notes/i }) as HTMLTextAreaElement).value).toBe('Test notes');
 
             // The date and time pickers are localized
-            expect((screen.getByRole('textbox', { name: /date/i }) as HTMLInputElement).value).toBe(formattedDate);
-            expect((screen.getByRole('textbox', { name: /start/i }) as HTMLInputElement).value).toBe(timeStartFormatted);
-            expect((screen.getByRole('textbox', { name: /end/i }) as HTMLInputElement).value).toBe(timeEndFormatted);
+            const dateGroup = screen.getByRole('group', { name: /date/i });
+            expect(within(dateGroup).getByRole('textbox', { hidden: true })).toHaveValue(formattedDate);
 
+            const startGroup = screen.getByRole('group', { name: /start/i });
+            expect(within(startGroup).getByRole('textbox', { hidden: true })).toHaveValue(timeStartFormatted);
+
+            const endGroup = screen.getByRole('group', { name: /end/i });
+            expect(within(endGroup).getByRole('textbox', { hidden: true })).toHaveValue(timeEndFormatted);
         });
     });
 


### PR DESCRIPTION
# Proposed Changes

The names of objects like muscles, equipment, etc. which come from the database / the server are translated. However, if the manual process is not run (e.g. because this is a local instance and the administrator does not commit the changes, etc.) we would show the internal translation key in the UI, instead of the original name.

## Related Issue(s)

Closes wger-project/wger#1825

