### PR TITLE
replace throttle by debounce in autocompleter

### DIFF
--- a/src/components/Exercises/Filter/NameAutcompleter.tsx
+++ b/src/components/Exercises/Filter/NameAutcompleter.tsx
@@ -1,5 +1,5 @@
-import PhotoIcon from '@mui/icons-material/Photo';
-import SearchIcon from '@mui/icons-material/Search';
+import PhotoIcon from "@mui/icons-material/Photo";
+import SearchIcon from "@mui/icons-material/Search";
 import {
     Autocomplete,
     Avatar,
@@ -10,7 +10,7 @@ import {
     ListItemIcon,
     ListItemText,
     Switch,
-    TextField
+    TextField,
 } from "@mui/material";
 import { SERVER_URL } from "config";
 import debounce from "lodash/debounce";
@@ -23,18 +23,17 @@ import { LANGUAGE_SHORT_ENGLISH } from "utils/consts";
 
 type NameAutocompleterProps = {
     callback: (exerciseResponse: ExerciseSearchResponse | null) => void;
-    loadExercise?: boolean
-}
+    loadExercise?: boolean;
+};
 
 export function NameAutocompleter({ callback, loadExercise }: NameAutocompleterProps) {
     const [value, setValue] = React.useState<ExerciseSearchResponse | null>(null);
-    const [inputValue, setInputValue] = React.useState('');
+    const [inputValue, setInputValue] = React.useState("");
     const [searchEnglish, setSearchEnglish] = useState<boolean>(true);
     const [options, setOptions] = React.useState<readonly ExerciseSearchResponse[]>([]);
     const [t, i18n] = useTranslation();
 
     loadExercise = loadExercise === undefined ? false : loadExercise;
-
 
     const fetchName = React.useMemo(
         () =>
@@ -43,31 +42,25 @@ export function NameAutocompleter({ callback, loadExercise }: NameAutocompleterP
                     searchExerciseTranslations(request, i18n.language, searchEnglish).then((res) => setOptions(res)),
                 200
             ),
-        [i18n.language, searchEnglish],
+        [i18n.language, searchEnglish]
     );
 
-
     React.useEffect(() => {
-
-        if (inputValue === '') {
+        if (inputValue === "") {
             setOptions(value ? [value] : []);
             return undefined;
         }
 
         fetchName(inputValue);
 
-        return () => {
-        };
+        return () => {};
     }, [value, inputValue, fetchName]);
-
 
     return (
         <>
             <Autocomplete
                 id="exercise-name-autocomplete"
-                getOptionLabel={(option) =>
-                    option.value
-                }
+                getOptionLabel={(option) => option.value}
                 data-testid="autocomplete"
                 filterOptions={(x) => x}
                 options={options}
@@ -75,7 +68,7 @@ export function NameAutocompleter({ callback, loadExercise }: NameAutocompleterP
                 includeInputInList
                 filterSelectedOptions
                 value={value}
-                noOptionsText={t('noResults')}
+                noOptionsText={t("noResults")}
                 isOptionEqualToValue={(option, value) => option.value === value.value}
                 onChange={async (event: any, newValue: ExerciseSearchResponse | null) => {
                     setOptions(newValue ? [newValue, ...options] : options);
@@ -91,7 +84,7 @@ export function NameAutocompleter({ callback, loadExercise }: NameAutocompleterP
                 renderInput={(params) => (
                     <TextField
                         {...params}
-                        label={t('exercises.searchExerciseName')}
+                        label={t("exercises.searchExerciseName")}
                         fullWidth
                         slotProps={{
                             input: {
@@ -103,21 +96,24 @@ export function NameAutocompleter({ callback, loadExercise }: NameAutocompleterP
                                         </InputAdornment>
                                         {params.InputProps.startAdornment}
                                     </>
-                                )
-                            }
+                                ),
+                            },
                         }}
                     />
                 )}
-                renderOption={(props, option, state) =>
-                    <li {...props}
+                renderOption={(props, option, state) => (
+                    <li
+                        {...props}
                         key={`exercise-${state.index}-${option.data.id}`}
                         data-testid={`autocompleter-result-${option.data.base_id}`}
                     >
                         <ListItem disablePadding component="div">
                             <ListItemIcon>
-                                {option.data.image ?
+                                {option.data.image ? (
                                     <Avatar alt="" src={`${SERVER_URL}${option.data.image}`} variant="rounded" />
-                                    : <PhotoIcon fontSize="large" />}
+                                ) : (
+                                    <PhotoIcon fontSize="large" />
+                                )}
                             </ListItemIcon>
                             <ListItemText
                                 primary={option.value}
@@ -132,14 +128,18 @@ export function NameAutocompleter({ callback, loadExercise }: NameAutocompleterP
                             />
                         </ListItem>
                     </li>
-                }
+                )}
             />
-            {i18n.language !== LANGUAGE_SHORT_ENGLISH && <FormGroup>
-                <FormControlLabel
-                    control={<Switch checked={searchEnglish}
-                                     onChange={(event, checked) => setSearchEnglish(checked)} />}
-                    label={t('alsoSearchEnglish')} />
-            </FormGroup>}
+            {i18n.language !== LANGUAGE_SHORT_ENGLISH && (
+                <FormGroup>
+                    <FormControlLabel
+                        control={
+                            <Switch checked={searchEnglish} onChange={(event, checked) => setSearchEnglish(checked)} />
+                        }
+                        label={t("alsoSearchEnglish")}
+                    />
+                </FormGroup>
+            )}
         </>
     );
 }

--- a/src/components/Exercises/Filter/NameAutcompleter.tsx
+++ b/src/components/Exercises/Filter/NameAutcompleter.tsx
@@ -121,12 +121,12 @@ export function NameAutocompleter({ callback, loadExercise }: NameAutocompleterP
                             </ListItemIcon>
                             <ListItemText
                                 primary={option.value}
-                                primaryTypographyProps={{
-                                    style: {
-                                        whiteSpace: 'nowrap',
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis'
-                                    }
+                                slotProps={{
+                                    primary: {
+                                        whiteSpace: "nowrap",
+                                        overflow: "hidden",
+                                        textOverflow: "ellipsis",
+                                    },
                                 }}
                                 secondary={option.data.category}
                             />

--- a/src/components/Exercises/Filter/NameAutcompleter.tsx
+++ b/src/components/Exercises/Filter/NameAutcompleter.tsx
@@ -13,7 +13,7 @@ import {
     TextField
 } from "@mui/material";
 import { SERVER_URL } from "config";
-import throttle from 'lodash/throttle';
+import debounce from "lodash/debounce";
 import * as React from "react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -38,9 +38,10 @@ export function NameAutocompleter({ callback, loadExercise }: NameAutocompleterP
 
     const fetchName = React.useMemo(
         () =>
-            throttle(
-                (request: string) => searchExerciseTranslations(request, i18n.language, searchEnglish).then(res => setOptions(res)),
-                200,
+            debounce(
+                (request: string) =>
+                    searchExerciseTranslations(request, i18n.language, searchEnglish).then((res) => setOptions(res)),
+                200
             ),
         [i18n.language, searchEnglish],
     );

--- a/src/components/Nutrition/widgets/IngredientAutcompleter.tsx
+++ b/src/components/Nutrition/widgets/IngredientAutcompleter.tsx
@@ -1,5 +1,5 @@
-import PhotoIcon from '@mui/icons-material/Photo';
-import SearchIcon from '@mui/icons-material/Search';
+import PhotoIcon from "@mui/icons-material/Photo";
+import SearchIcon from "@mui/icons-material/Search";
 import {
     Autocomplete,
     Avatar,
@@ -11,12 +11,12 @@ import {
     ListItemText,
     Stack,
     Switch,
-    TextField
+    TextField,
 } from "@mui/material";
 import { SERVER_URL } from "config";
 import debounce from "lodash/debounce";
 import * as React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { searchIngredient } from "services";
 import { IngredientSearchResponse } from "services/responseType";
@@ -25,28 +25,25 @@ import { LANGUAGE_SHORT_ENGLISH } from "utils/consts";
 type IngredientAutocompleterProps = {
     callback: Function;
     initialIngredient?: string | null;
-}
+};
 
 export function IngredientAutocompleter({ callback, initialIngredient }: IngredientAutocompleterProps) {
-
-
     const initialData = initialIngredient
         ? {
-            value: initialIngredient,
-            data: {
-                id: -1,
-                name: initialIngredient,
-                image: null,
-                // eslint-disable-next-line camelcase
-                image_thumbnail: null,
-            }
-        }
+              value: initialIngredient,
+              data: {
+                  id: -1,
+                  name: initialIngredient,
+                  image: null,
+                  // eslint-disable-next-line camelcase
+                  image_thumbnail: null,
+              },
+          }
         : null;
-
 
     const [searchEnglish, setSearchEnglish] = useState<boolean>(true);
     const [value, setValue] = useState<IngredientSearchResponse | null>(initialData);
-    const [inputValue, setInputValue] = useState('');
+    const [inputValue, setInputValue] = useState("");
     const [options, setOptions] = useState<readonly IngredientSearchResponse[]>([]);
     const [t, i18n] = useTranslation();
 
@@ -57,13 +54,11 @@ export function IngredientAutocompleter({ callback, initialIngredient }: Ingredi
                     searchIngredient(request, i18n.language, searchEnglish).then((res) => setOptions(res)),
                 200
             ),
-        [i18n.language, searchEnglish],
+        [i18n.language, searchEnglish]
     );
 
-
     useEffect(() => {
-
-        if (inputValue === '') {
+        if (inputValue === "") {
             setOptions(value ? [value] : []);
             return undefined;
         }
@@ -71,36 +66,37 @@ export function IngredientAutocompleter({ callback, initialIngredient }: Ingredi
         fetchName(inputValue);
 
         return () => {
+            fetchName.cancel();
         };
     }, [value, inputValue, fetchName]);
 
-
-    return <Stack>
-        <Autocomplete
-            id="ingredient-autocomplete"
-            getOptionLabel={(option) => option.value}
-            data-testid="autocomplete"
-            filterOptions={(x) => x}
-            options={options}
-            autoComplete
-            includeInputInList
-            filterSelectedOptions
-            value={value}
-            noOptionsText={t('noResults')}
-            isOptionEqualToValue={(option, value) => option.value === value.value}
-            onChange={(event: any, newValue: IngredientSearchResponse | null) => {
-                setOptions(newValue ? [newValue, ...options] : options);
-                setValue(newValue);
-                callback(newValue);
-            }}
-            onInputChange={(event, newInputValue) => {
-                setInputValue(newInputValue);
-            }}
-            renderInput={(params) => (
-                <TextField
-                    {...params}
-                    label={t('nutrition.searchIngredientName')}
-                    fullWidth
+    return (
+        <Stack>
+            <Autocomplete
+                id="ingredient-autocomplete"
+                getOptionLabel={(option) => option.value}
+                data-testid="autocomplete"
+                filterOptions={(x) => x}
+                options={options}
+                autoComplete
+                includeInputInList
+                filterSelectedOptions
+                value={value}
+                noOptionsText={t("noResults")}
+                isOptionEqualToValue={(option, value) => option.value === value.value}
+                onChange={(event: unknown, newValue: IngredientSearchResponse | null) => {
+                    setOptions(newValue ? [newValue, ...options] : options);
+                    setValue(newValue);
+                    callback(newValue);
+                }}
+                onInputChange={(event, newInputValue) => {
+                    setInputValue(newInputValue);
+                }}
+                renderInput={(params) => (
+                    <TextField
+                        {...params}
+                        label={t("nutrition.searchIngredientName")}
+                        fullWidth
                         slotProps={{
                             input: {
                                 ...params.InputProps,
@@ -114,21 +110,19 @@ export function IngredientAutocompleter({ callback, initialIngredient }: Ingredi
                                 ),
                             },
                         }}
-                />
-            )}
-            renderOption={(props, option) => {
-                return (
-                    <li {...props} key={`ingredient-${option.data.id}`}>
-                        <ListItem disablePadding component="div">
-                            <ListItemIcon>
-                                <Avatar alt="" src={`${SERVER_URL}${option.data.image}`} variant="rounded">
-                                    <PhotoIcon />
-                                </Avatar>
-
-
-                            </ListItemIcon>
-                            <ListItemText
-                                primary={option.value}
+                    />
+                )}
+                renderOption={(props, option) => {
+                    return (
+                        <li {...props} key={`ingredient-${option.data.id}`}>
+                            <ListItem disablePadding component="div">
+                                <ListItemIcon>
+                                    <Avatar alt="" src={`${SERVER_URL}${option.data.image}`} variant="rounded">
+                                        <PhotoIcon />
+                                    </Avatar>
+                                </ListItemIcon>
+                                <ListItemText
+                                    primary={option.value}
                                     slotProps={{
                                         primary: {
                                             whiteSpace: "nowrap",
@@ -136,16 +130,22 @@ export function IngredientAutocompleter({ callback, initialIngredient }: Ingredi
                                             textOverflow: "ellipsis",
                                         },
                                     }}
-                            />
-                        </ListItem>
-                    </li>
-                );
-            }}
-        />
-        {i18n.language !== LANGUAGE_SHORT_ENGLISH && <FormGroup>
-            <FormControlLabel
-                control={<Switch checked={searchEnglish} onChange={(event, checked) => setSearchEnglish(checked)} />}
-                label={t('alsoSearchEnglish')} />
-        </FormGroup>}
-    </Stack>;
+                                />
+                            </ListItem>
+                        </li>
+                    );
+                }}
+            />
+            {i18n.language !== LANGUAGE_SHORT_ENGLISH && (
+                <FormGroup>
+                    <FormControlLabel
+                        control={
+                            <Switch checked={searchEnglish} onChange={(event, checked) => setSearchEnglish(checked)} />
+                        }
+                        label={t("alsoSearchEnglish")}
+                    />
+                </FormGroup>
+            )}
+        </Stack>
+    );
 }

--- a/src/components/Nutrition/widgets/IngredientAutcompleter.tsx
+++ b/src/components/Nutrition/widgets/IngredientAutcompleter.tsx
@@ -101,17 +101,19 @@ export function IngredientAutocompleter({ callback, initialIngredient }: Ingredi
                     {...params}
                     label={t('nutrition.searchIngredientName')}
                     fullWidth
-                    InputProps={{
-                        ...params.InputProps,
-                        startAdornment: (
-                            <>
-                                <InputAdornment position="start">
-                                    <SearchIcon />
-                                </InputAdornment>
-                                {params.InputProps.startAdornment}
-                            </>
-                        )
-                    }}
+                        slotProps={{
+                            input: {
+                                ...params.InputProps,
+                                startAdornment: (
+                                    <>
+                                        <InputAdornment position="start">
+                                            <SearchIcon />
+                                        </InputAdornment>
+                                        {params.InputProps.startAdornment}
+                                    </>
+                                ),
+                            },
+                        }}
                 />
             )}
             renderOption={(props, option) => {
@@ -127,13 +129,13 @@ export function IngredientAutocompleter({ callback, initialIngredient }: Ingredi
                             </ListItemIcon>
                             <ListItemText
                                 primary={option.value}
-                                primaryTypographyProps={{
-                                    style: {
-                                        whiteSpace: 'nowrap',
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis'
-                                    }
-                                }}
+                                    slotProps={{
+                                        primary: {
+                                            whiteSpace: "nowrap",
+                                            overflow: "hidden",
+                                            textOverflow: "ellipsis",
+                                        },
+                                    }}
                             />
                         </ListItem>
                     </li>

--- a/src/components/Nutrition/widgets/IngredientAutcompleter.tsx
+++ b/src/components/Nutrition/widgets/IngredientAutcompleter.tsx
@@ -14,7 +14,7 @@ import {
     TextField
 } from "@mui/material";
 import { SERVER_URL } from "config";
-import throttle from 'lodash/throttle';
+import debounce from "lodash/debounce";
 import * as React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from "react-i18next";
@@ -52,9 +52,10 @@ export function IngredientAutocompleter({ callback, initialIngredient }: Ingredi
 
     const fetchName = useMemo(
         () =>
-            throttle(
-                (request: string) => searchIngredient(request, i18n.language, searchEnglish).then(res => setOptions(res)),
-                200,
+            debounce(
+                (request: string) =>
+                    searchIngredient(request, i18n.language, searchEnglish).then((res) => setOptions(res)),
+                200
             ),
         [i18n.language, searchEnglish],
     );


### PR DESCRIPTION
# Proposed Changes

- Changing throttle to debounce

When users search an exercise or ingredient, it'll chain searches on almost each keystrokes based on the throttling value, so I replaced it with debounce which wait for the user to stop typing before triggering the request

# Updates

- Some properties of MUI were deprecated (primaryTypographyProps & inputProps) and were replaced with their current properties, recommended by MUI's docs.