### PR TITLE
Fix routine list thumbnail overlapping text

### DIFF
--- a/src/components/Exercises/Detail/ExerciseImageAvatar.tsx
+++ b/src/components/Exercises/Detail/ExerciseImageAvatar.tsx
@@ -12,7 +12,7 @@ export const ExerciseImageAvatar = (props: {
     const iconSize = props.iconSize || 40;
 
     return <Avatar
-        sx={{ height: avatarSize, width: avatarSize, }}
+        sx={{ height: avatarSize, width: avatarSize, flexShrink: 0 }}
         src={props.image?.url}
     >
         <PhotoIcon sx={{ height: iconSize, width: iconSize }} />

--- a/src/components/WorkoutRoutines/widgets/RoutineDetailsCard.tsx
+++ b/src/components/WorkoutRoutines/widgets/RoutineDetailsCard.tsx
@@ -118,10 +118,15 @@ function SlotDataList(props: {
     return (
         <Grid
             container
-            justifyContent="space-between"
             alignItems="flex-start"
+            columnGap={1}
+            wrap="nowrap"
         >
-            <Grid size={1}>
+            <Grid
+                sx={{
+                    flex: '0 0 50px',
+                }}
+            >
                 <Stack divider={<Box height="10px" />}>
                     {props.slotData.exercises.map((exercise, index) =>
                         <ExerciseImageAvatar
@@ -134,22 +139,23 @@ function SlotDataList(props: {
                 </Stack>
             </Grid>
 
-            <Grid size={11}>
+            <Grid
+                sx={{ flex: '1 1 auto', minWidth: 0 }}
+            >
                 {props.slotData.setConfigs.map((setConfig, index) => {
-                        // Only show the name of the exercise the first time it appears
-                        const showExercise = index === 0 || setConfig.exerciseId !== props.slotData.setConfigs[index - 1]?.exerciseId;
-                        return <SetConfigDataDetails
-                            setConfigData={setConfig}
-                            marginBottom="1em"
-                            key={index}
-                            showExercise={showExercise}
-                        />;
-                    }
-                )}
+                    const showExercise = index === 0 || setConfig.exerciseId !== props.slotData.setConfigs[index - 1]?.exerciseId;
+                    return <SetConfigDataDetails
+                        setConfigData={setConfig}
+                        marginBottom="1em"
+                        key={index}
+                        showExercise={showExercise}
+                    />;
+                })}
             </Grid>
         </Grid>
     );
 }
+
 
 export const DayDetailsCard = (props: { dayData: RoutineDayData, routineId: number, readOnly?: boolean }) => {
     const readOnly = (props.readOnly ?? false) || props.dayData.day === null || props.dayData.day.isRest;


### PR DESCRIPTION
# Proposed Changes

- Fixed the issue where the distance between thumbnails and text would shorten, obscuring the latter.
- Make the routine row a **non-wrapping flex layout** with a fixed thumbnail column and fluid text column. 

## Related Issue(s)
Closes #1120

## Please check that the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features) 
       *Verified manually with screenshots.*
<img width="628" height="854" alt="67c83249-8df4-498e-ae90-1d4ab3cf72c3" src="https://github.com/user-attachments/assets/341fda20-1c44-4123-a3a4-5c66bb9ad9f9" />

