### PR TITLE
Align FABs with main content container

### DIFF
--- a/src/components/BodyWeight/Table/Fab/Fab.tsx
+++ b/src/components/BodyWeight/Table/Fab/Fab.tsx
@@ -22,7 +22,7 @@ export const WeightEntryFab = () => {
                 sx={{
                     position: 'fixed',
                     bottom: '5rem',
-                    right: (theme) => theme.spacing(2),
+                    right: (theme) => `max(${theme.spacing(2)}, calc((100vw - ${theme.breakpoints.values.lg}px) / 2 + ${theme.spacing(2)}))`,
                     zIndex: 9,
                 }}>
                 <AddIcon />

--- a/src/components/BodyWeight/widgets/fab.tsx
+++ b/src/components/BodyWeight/widgets/fab.tsx
@@ -20,7 +20,7 @@ export const AddBodyWeightEntryFab = () => {
                 sx={{
                     position: 'fixed',
                     bottom: '5rem',
-                    right: (theme) => theme.spacing(2),
+                    right: (theme) => `max(${theme.spacing(2)}, calc((100vw - ${theme.breakpoints.values.lg}px) / 2 + ${theme.spacing(2)}))`,
                     zIndex: 9,
                 }}>
                 <AddIcon />

--- a/src/components/Measurements/widgets/fab.tsx
+++ b/src/components/Measurements/widgets/fab.tsx
@@ -23,7 +23,7 @@ export const AddMeasurementCategoryFab = () => {
                 sx={{
                     position: 'fixed',
                     bottom: '5rem',
-                    right: (theme) => theme.spacing(2),
+                    right: (theme) => `max(${theme.spacing(2)}, calc((100vw - ${theme.breakpoints.values.lg}px) / 2 + ${theme.spacing(2)}))`,
                     zIndex: 9,
                 }}>
                 <AddIcon />
@@ -53,7 +53,7 @@ export const AddMeasurementEntryFab = () => {
             sx={{
                 position: 'fixed',
                 bottom: '5rem',
-                right: (theme) => theme.spacing(2),
+                right: (theme) => `max(${theme.spacing(2)}, calc((100vw - ${theme.breakpoints.values.lg}px) / 2 + ${theme.spacing(2)}))`,
                 zIndex: 9,
             }}>
             <AddIcon />

--- a/src/components/Nutrition/widgets/Fab.tsx
+++ b/src/components/Nutrition/widgets/Fab.tsx
@@ -24,7 +24,7 @@ export const AddNutritionalPlanFab = () => {
                 sx={{
                     position: 'fixed',
                     bottom: '5rem',
-                    right: (theme) => theme.spacing(2),
+                    right: (theme) => `max(${theme.spacing(2)}, calc((100vw - ${theme.breakpoints.values.lg}px) / 2 + ${theme.spacing(2)}))`,
                     zIndex: 9,
                 }}>
                 <AddIcon />
@@ -52,7 +52,7 @@ export const AddNutritionDiaryEntryFab = (props: { plan: NutritionalPlan }) => {
                 sx={{
                     position: 'fixed',
                     bottom: '5rem',
-                    right: (theme) => theme.spacing(2),
+                    right: (theme) => `max(${theme.spacing(2)}, calc((100vw - ${theme.breakpoints.values.lg}px) / 2 + ${theme.spacing(2)}))`,
                     zIndex: 9,
                 }}>
                 <HistoryEduIcon />

--- a/src/components/WorkoutRoutines/Overview/Fab.tsx
+++ b/src/components/WorkoutRoutines/Overview/Fab.tsx
@@ -22,7 +22,7 @@ export const AddRoutineFab = () => {
                 sx={{
                     position: 'fixed',
                     bottom: '5rem',
-                    right: (theme) => theme.spacing(2),
+                    right: (theme) => `max(${theme.spacing(2)}, calc((100vw - ${theme.breakpoints.values.lg}px) / 2 + ${theme.spacing(2)}))`,
                     zIndex: 9,
                 }}>
                 <AddIcon />
@@ -50,7 +50,7 @@ export const AddPublicTemplateFab = () => {
                 sx={{
                     position: 'fixed',
                     bottom: '5rem',
-                    right: (theme) => theme.spacing(2),
+                    right: (theme) => `max(${theme.spacing(2)}, calc((100vw - ${theme.breakpoints.values.lg}px) / 2 + ${theme.spacing(2)}))`,
                     zIndex: 9,
                 }}>
                 <AddIcon />
@@ -78,7 +78,7 @@ export const AddPrivateTemplateFab = () => {
                 sx={{
                     position: 'fixed',
                     bottom: '5rem',
-                    right: (theme) => theme.spacing(2),
+                    right: (theme) => `max(${theme.spacing(2)}, calc((100vw - ${theme.breakpoints.values.lg}px) / 2 + ${theme.spacing(2)}))`,
                     zIndex: 9,
                 }}>
                 <AddIcon />


### PR DESCRIPTION
# Proposed Changes
- Align FABs with the main content instead of the screen edge for better UX on wide screens.
- Applied alignment on all FAB components (nutrition, measurements, body weight, workout routines)

# Responsive Behaviour
- Narrow screens (≤1200px): FAB stays 16px from the right edge
<img width="1018" height="742" alt="Screenshot 2025-09-28 at 8 49 57 PM" src="https://github.com/user-attachments/assets/174e414a-dca7-429e-b126-4b8727b20fe0" />

- Wide screens (>1200px): FAB aligns with the container right edge
<img width="1511" height="749" alt="Screenshot 2025-09-28 at 8 46 15 PM" src="https://github.com/user-attachments/assets/df46a709-d4b2-42b1-8628-e20f2f4d60cd" />

## Related Issue(s)
close #1122

- [ ] Tests for the changes have been added (for bug fixes / features)  
  N/A – CSS styling change only, no logic changes. Tested manually on different screen sizes.