### PR TITLE
fix: add numeric keypad hints for weight and repetitions fields on mobile

### DIFF
--- a/src/components/Measurements/widgets/EntryForm.tsx
+++ b/src/components/Measurements/widgets/EntryForm.tsx
@@ -100,16 +100,16 @@ export const EntryForm = ({ entry, closeFn, categoryId }: EntryFormProps) => {
                                 />
                             </LocalizationProvider>}
 
-                        <TextField
+                       <TextField
                             fullWidth
-                            id="notes"
-                            label={t('notes')}
-                            multiline
-                            error={formik.touched.notes && Boolean(formik.errors.notes)}
-                            helperText={formik.touched.notes && formik.errors.notes}
-                            {...formik.getFieldProps('notes')}
-                        />
-
+                            id="value"
+                            type={"number"}
+                           label={t('value')}
+                           error={formik.touched.value && Boolean(formik.errors.value)}
+                           helperText={formik.touched.value && formik.errors.value}
+                           inputProps={{ inputMode: 'decimal' }}
+                           {...formik.getFieldProps('value')}
+                   />
                         <Stack direction="row" sx={{ justifyContent: "end", mt: 2 }}>
                             <Button color="primary" variant="contained" type="submit" sx={{ mt: 2 }}>
                                 {t('submit')}

--- a/src/components/Measurements/widgets/EntryForm.tsx
+++ b/src/components/Measurements/widgets/EntryForm.tsx
@@ -81,6 +81,7 @@ export const EntryForm = ({ entry, closeFn, categoryId }: EntryFormProps) => {
                             label={t('value')}
                             error={formik.touched.value && Boolean(formik.errors.value)}
                             helperText={formik.touched.value && formik.errors.value}
+                            slotProps={{ htmlInput: { inputMode: 'decimal' } }}
                             {...formik.getFieldProps('value')}
                         />
                         {categoryQuery.isLoading
@@ -100,16 +101,15 @@ export const EntryForm = ({ entry, closeFn, categoryId }: EntryFormProps) => {
                                 />
                             </LocalizationProvider>}
 
-                       <TextField
+                        <TextField
                             fullWidth
-                            id="value"
-                            type={"number"}
-                           label={t('value')}
-                           error={formik.touched.value && Boolean(formik.errors.value)}
-                           helperText={formik.touched.value && formik.errors.value}
-                           inputProps={{ inputMode: 'decimal' }}
-                           {...formik.getFieldProps('value')}
-                   />
+                            id="notes"
+                            label={t('notes')}
+                            multiline
+                            error={formik.touched.notes && Boolean(formik.errors.notes)}
+                            helperText={formik.touched.notes && formik.errors.notes}
+                            {...formik.getFieldProps('notes')}
+                        />
                         <Stack direction="row" sx={{ justifyContent: "end", mt: 2 }}>
                             <Button color="primary" variant="contained" type="submit" sx={{ mt: 2 }}>
                                 {t('submit')}

--- a/src/components/Nutrition/screens/BmiCalculator.tsx
+++ b/src/components/Nutrition/screens/BmiCalculator.tsx
@@ -98,17 +98,18 @@ export const BmiCalculator = () => {
                 <Stack spacing={2}>
                     <Grid container spacing={2}>
                         <Grid size={{ xs: 12, sm: 6 }}>
- <TextField
-    label={t('height')}
-    fullWidth
-    slotProps={{
-        input: { endAdornment: <Typography>{t('cm')}</Typography> },
-        htmlInput: { inputMode: 'decimal' }
-    }}
-    type="number"
-    value={height ?? ""}
-    onChange={(e) => setHeight(parseFloat(e.target.value))}
-/></Grid>
+                            <TextField
+                                label={t('height')}
+                                fullWidth
+                                slotProps={{
+                                    input: { endAdornment: <Typography>{t('cm')}</Typography> },
+                                    htmlInput: { inputMode: 'decimal' }
+                                }}
+                                type="number"
+                                value={height ?? ""}
+                                onChange={(e) => setHeight(parseFloat(e.target.value))}
+                            />
+                        </Grid>
                         <Grid size={{ xs: 12, sm: 6 }}>
                             <TextField
                                 label={t('weight')}

--- a/src/components/Nutrition/screens/BmiCalculator.tsx
+++ b/src/components/Nutrition/screens/BmiCalculator.tsx
@@ -113,8 +113,8 @@ export const BmiCalculator = () => {
                             <TextField
                                 label={t('weight')}
                                 slotProps={{
-                                    input: { endAdornment: <Typography>{t('server.kg')}</Typography> }
-                                        htmlInput: { inputMode: 'decimal' }
+                                    input: { endAdornment: <Typography>{t('server.kg')}</Typography> },
+                                    htmlInput: { inputMode: 'decimal' }
                                 }}
                                 fullWidth
                                 type="number"

--- a/src/components/Nutrition/screens/BmiCalculator.tsx
+++ b/src/components/Nutrition/screens/BmiCalculator.tsx
@@ -98,22 +98,23 @@ export const BmiCalculator = () => {
                 <Stack spacing={2}>
                     <Grid container spacing={2}>
                         <Grid size={{ xs: 12, sm: 6 }}>
-                            <TextField
-                                label={t('height')}
-                                fullWidth
-                                slotProps={{
-                                    input: { endAdornment: <Typography>{t('cm')}</Typography> }
-                                }}
-                                type="number"
-                                value={height ?? ""}
-                                onChange={(e) => setHeight(parseFloat(e.target.value))}
-                            />
-                        </Grid>
+ <TextField
+    label={t('height')}
+    fullWidth
+    slotProps={{
+        input: { endAdornment: <Typography>{t('cm')}</Typography> },
+        htmlInput: { inputMode: 'decimal' }
+    }}
+    type="number"
+    value={height ?? ""}
+    onChange={(e) => setHeight(parseFloat(e.target.value))}
+/></Grid>
                         <Grid size={{ xs: 12, sm: 6 }}>
                             <TextField
                                 label={t('weight')}
                                 slotProps={{
                                     input: { endAdornment: <Typography>{t('server.kg')}</Typography> }
+                                        htmlInput: { inputMode: 'decimal' }
                                 }}
                                 fullWidth
                                 type="number"

--- a/src/components/Routines/widgets/forms/SessionLogsForm.tsx
+++ b/src/components/Routines/widgets/forms/SessionLogsForm.tsx
@@ -247,11 +247,10 @@ export const SessionLogsForm = ({ dayId, routineId, selectedDate }: SessionLogsF
                                                                         </Typography>
                                                                         : null}
                                                                 </InputAdornment>
-
                                                         },
-                                                     htmlInput:{
-                                                           inputMode: 'decimal'
-                                                       }
+                                                        htmlInput: {
+                                                            inputMode: 'decimal'
+                                                        }
                                                     }
                                                 }}
                                             />
@@ -270,11 +269,10 @@ export const SessionLogsForm = ({ dayId, routineId, selectedDate }: SessionLogsF
                                                                     </Typography>
                                                                 </InputAdornment>
                                                         },
-                                                         htmlInput: {
-                                                                inputMode: 'decimal'
-                                                           }
-                                                                          
-                                                      }
+                                                        htmlInput: {
+                                                            inputMode: 'decimal'
+                                                        }
+                                                    }
                                                 }}
                                             />
                                         </Grid>

--- a/src/components/Routines/widgets/forms/SessionLogsForm.tsx
+++ b/src/components/Routines/widgets/forms/SessionLogsForm.tsx
@@ -248,7 +248,10 @@ export const SessionLogsForm = ({ dayId, routineId, selectedDate }: SessionLogsF
                                                                         : null}
                                                                 </InputAdornment>
 
-                                                        }
+                                                        },
+                                                     htmlInput:{
+                                                           inputMode: 'numeric'
+                                                       }
                                                     }
                                                 }}
                                             />
@@ -266,8 +269,12 @@ export const SessionLogsForm = ({ dayId, routineId, selectedDate }: SessionLogsF
                                                                         {formik.values.logs[index].weightUnit?.name}
                                                                     </Typography>
                                                                 </InputAdornment>
-                                                        }
-                                                    }
+                                                        },
+                                                         htmlInput: {
+                                                                inputMode: 'decimal'
+                                                           }
+                                                                          
+                                                      }
                                                 }}
                                             />
                                         </Grid>

--- a/src/components/Routines/widgets/forms/SessionLogsForm.tsx
+++ b/src/components/Routines/widgets/forms/SessionLogsForm.tsx
@@ -250,7 +250,7 @@ export const SessionLogsForm = ({ dayId, routineId, selectedDate }: SessionLogsF
 
                                                         },
                                                      htmlInput:{
-                                                           inputMode: 'numeric'
+                                                           inputMode: 'decimal'
                                                        }
                                                     }
                                                 }}


### PR DESCRIPTION
Fixes #2409 (wger-project/wger)

## Problem
On mobile browsers (iOS Safari, Chrome), the workout log input fields 
for repetitions and weight show a full text keyboard instead of a 
numeric keypad, making it slower to enter values during workouts.

## Solution
Added inputMode hints to the input fields:
- repetitions field: inputMode="numeric"  
- weight field: inputMode="decimal"

This tells mobile browsers to show the appropriate numeric keypad 
while preserving existing functionality.

## Testing
Tested on mobile browser - numeric keypad now appears when tapping 
weight and repetitions fields.
