### PR TITLE
Fix routine table log icons wrapping to new line

### DIFF
--- a/src/components/Routines/screens/Detail/RoutineDetailsTable.tsx
+++ b/src/components/Routines/screens/Detail/RoutineDetailsTable.tsx
@@ -13,6 +13,7 @@ import FlagCircleIcon from '@mui/icons-material/FlagCircle';
 import NorthEastIcon from "@mui/icons-material/NorthEast";
 import SouthEastIcon from "@mui/icons-material/SouthEast";
 import {
+    Box,
     Container,
     FormControlLabel,
     Stack,
@@ -275,40 +276,40 @@ export const RoutineTable = (props: {
                     <TableCell align={'center'} sx={{ verticalAlign: "top" }}>
                         {logs.map((log) =>
                             <Stack key={log.id}>
-                                <span>
+                                <Box component="span" sx={{ whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'center', gap: '2px' }}>
                                     {log.repetitions ?? '-/-'}
                                     {getComparisonIcon(log.repetitions, setConfig?.repetitions, setConfig?.maxRepetitions)}
-                                </span>
+                                </Box>
                             </Stack>
                         )}
                     </TableCell>
                     <TableCell align={'center'} sx={{ verticalAlign: "top" }}>
                         {logs.map((log) =>
                             <Stack key={log.id}>
-                                <span>
+                                <Box component="span" sx={{ whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'center', gap: '2px' }}>
                                     {log.weight ?? '-/-'}
                                     {getComparisonIcon(log.weight, setConfig?.weight, setConfig?.maxWeight)}
-                                </span>
+                                </Box>
                             </Stack>
                         )}
                     </TableCell>
                     <TableCell align={'center'} sx={{ verticalAlign: "top" }}>
                         {logs.map((log) =>
                             <Stack key={log.id}>
-                                <span>
+                                <Box component="span" sx={{ whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'center', gap: '2px' }}>
                                     {log.restTime ?? '-/-'}
                                     {getComparisonIcon(log.restTime, setConfig?.restTime, setConfig?.maxRestTime)}
-                                </span>
+                                </Box>
                             </Stack>
                         )}
                     </TableCell>
                     <TableCell align={'center'} sx={{ verticalAlign: "top" }}>
                         {logs.map((log) =>
                             <Stack key={log.id}>
-                                <span>
+                                <Box component="span" sx={{ whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'center', gap: '2px' }}>
                                     {log.rir ?? '-/-'}
                                     {getComparisonIcon(log.rir, setConfig?.rir, setConfig?.maxRir, false)}
-                                </span>
+                                </Box>
                             </Stack>
                         )}
                     </TableCell>


### PR DESCRIPTION
Closes #1264

   The comparison icons (up/down/flag) in the "Logged" row of the routine
   table view (/routine/<id>/table) were wrapping onto their own line below
   the logged value instead of staying next to it, since the value and icon
   were rendered inside a plain <span> with no layout control.

   Fixed by wrapping the value + icon in a Box with display: inline-flex,
   alignItems: center, and a small gap, applied consistently across all four
   logged columns (reps, weight, rest time, RiR).


<img width="483" height="508" alt="WhatsApp Image 2026-07-06 at 13 54 33" src="https://github.com/user-attachments/assets/5fe8906d-2fe4-4a30-95a5-08787a9dcd90" />

