### PR TITLE
fix: keep comparison icons beside logged values in routine table (#1264)

### DIFF
--- a/src/components/Routines/screens/Detail/RoutineDetailsTable.tsx
+++ b/src/components/Routines/screens/Detail/RoutineDetailsTable.tsx
@@ -259,6 +259,24 @@ export const RoutineTable = (props: {
 
     }
 
+    function renderLoggedValueWithIcon(
+        value: React.ReactNode,
+        icon: React.ReactNode,
+    ) {
+        return (
+            <Stack
+                direction="row"
+                alignItems="center"
+                justifyContent="center"
+                spacing={0.25}
+                sx={{ whiteSpace: 'nowrap' }}
+            >
+                <span>{value}</span>
+                {icon}
+            </Stack>
+        );
+    }
+
     function getTableRowLogged(slotEntry: SlotEntry, day: Day) {
         return <TableRow>
             <TableCell sx={{ verticalAlign: "top", backgroundColor: "white" }} className={classes.stickyColumn}>
@@ -275,40 +293,40 @@ export const RoutineTable = (props: {
                     <TableCell align={'center'} sx={{ verticalAlign: "top" }}>
                         {logs.map((log) =>
                             <Stack key={log.id}>
-                                <span>
-                                    {log.repetitions ?? '-/-'}
-                                    {getComparisonIcon(log.repetitions, setConfig?.repetitions, setConfig?.maxRepetitions)}
-                                </span>
+                                {renderLoggedValueWithIcon(
+                                    log.repetitions ?? '-/-',
+                                    getComparisonIcon(log.repetitions, setConfig?.repetitions, setConfig?.maxRepetitions),
+                                )}
                             </Stack>
                         )}
                     </TableCell>
                     <TableCell align={'center'} sx={{ verticalAlign: "top" }}>
                         {logs.map((log) =>
                             <Stack key={log.id}>
-                                <span>
-                                    {log.weight ?? '-/-'}
-                                    {getComparisonIcon(log.weight, setConfig?.weight, setConfig?.maxWeight)}
-                                </span>
+                                {renderLoggedValueWithIcon(
+                                    log.weight ?? '-/-',
+                                    getComparisonIcon(log.weight, setConfig?.weight, setConfig?.maxWeight),
+                                )}
                             </Stack>
                         )}
                     </TableCell>
                     <TableCell align={'center'} sx={{ verticalAlign: "top" }}>
                         {logs.map((log) =>
                             <Stack key={log.id}>
-                                <span>
-                                    {log.restTime ?? '-/-'}
-                                    {getComparisonIcon(log.restTime, setConfig?.restTime, setConfig?.maxRestTime)}
-                                </span>
+                                {renderLoggedValueWithIcon(
+                                    log.restTime ?? '-/-',
+                                    getComparisonIcon(log.restTime, setConfig?.restTime, setConfig?.maxRestTime),
+                                )}
                             </Stack>
                         )}
                     </TableCell>
                     <TableCell align={'center'} sx={{ verticalAlign: "top" }}>
                         {logs.map((log) =>
                             <Stack key={log.id}>
-                                <span>
-                                    {log.rir ?? '-/-'}
-                                    {getComparisonIcon(log.rir, setConfig?.rir, setConfig?.maxRir, false)}
-                                </span>
+                                {renderLoggedValueWithIcon(
+                                    log.rir ?? '-/-',
+                                    getComparisonIcon(log.rir, setConfig?.rir, setConfig?.maxRir, false),
+                                )}
                             </Stack>
                         )}
                     </TableCell>


### PR DESCRIPTION
## Summary

Routine table log comparison icons can wrap away from their numeric values when cells are narrow.

## Changes

- Add a small helper to render logged value + comparison icon as a centered horizontal `Stack`
- Apply it to reps, weight, rest time, and RIR log rows
- Keep the value/icon pair non-wrapping with `whiteSpace: 'nowrap'`

## Tests

`LANG=de_de npx vitest run src/components/Routines/screens/Detail/RoutineDetailsTable.test.tsx`

Fixes #1264
