### PR TITLE
fix: restored calendar viewport height so entries panel scrolls internally

### DIFF
--- a/src/components/Calendar/Components/CalendarComponent.tsx
+++ b/src/components/Calendar/Components/CalendarComponent.tsx
@@ -170,7 +170,7 @@ const CalendarComponent = (props: { showBorder?: boolean }) => {
             display: 'flex',
             gap: 2,
             flexDirection: { xs: 'column', md: 'row' },
-            // height: { xs: 'auto', md: 'calc(100vh - 130px)' },
+            height: { xs: 'auto', md: showBorder ? 'calc(100vh - 130px)' : 'auto' },
             width: '100%',
         }}>
             <Card sx={{


### PR DESCRIPTION
Restored the commented-out viewport height on the calendar container so the Entries panel scrolls internally instead of the whole page.

Fixes #1993